### PR TITLE
added option to collect "all tweets" or just "top tweets"

### DIFF
--- a/got/manager/TweetCriteria.py
+++ b/got/manager/TweetCriteria.py
@@ -22,3 +22,7 @@ class TweetCriteria:
 	def setMaxTweets(self, maxTweets):
 		self.maxTweets = maxTweets
 		return self
+
+	def setAllTweets(self, allTweets=False):
+		self.allTweets = allTweets
+		return self

--- a/got/manager/TweetCriteria.py
+++ b/got/manager/TweetCriteria.py
@@ -1,27 +1,24 @@
 class TweetCriteria:
-
-    def __init__(self):
-        self.maxTweets = 0
-
-    def setUsername(self, username):
-        self.username = username
-        return self
-
-    def setSince(self, since):
-        self.since = since
-        return self
-
-    def setUntil(self, until):
-        self.until = until
-        return self
-
-    def setQuerySearch(self, querySearch):
-        self.querySearch = querySearch
-        return self
-
-    def setMaxTweets(self, maxTweets):
-        self.maxTweets = maxTweets
-        return self
-
-    def setAllTweets(self, allTweets=False):
-        self.allTweets = allTweets
+	
+	def __init__(self):
+		self.maxTweets = 0
+		
+	def setUsername(self, username):
+		self.username = username
+		return self
+		
+	def setSince(self, since):
+		self.since = since
+		return self
+	
+	def setUntil(self, until):
+		self.until = until
+		return self
+		
+	def setQuerySearch(self, querySearch):
+		self.querySearch = querySearch
+		return self
+		
+	def setMaxTweets(self, maxTweets):
+		self.maxTweets = maxTweets
+		return self

--- a/got/manager/TweetCriteria.py
+++ b/got/manager/TweetCriteria.py
@@ -1,24 +1,27 @@
 class TweetCriteria:
-	
-	def __init__(self):
-		self.maxTweets = 0
-		
-	def setUsername(self, username):
-		self.username = username
-		return self
-		
-	def setSince(self, since):
-		self.since = since
-		return self
-	
-	def setUntil(self, until):
-		self.until = until
-		return self
-		
-	def setQuerySearch(self, querySearch):
-		self.querySearch = querySearch
-		return self
-		
-	def setMaxTweets(self, maxTweets):
-		self.maxTweets = maxTweets
-		return self
+
+    def __init__(self):
+        self.maxTweets = 0
+
+    def setUsername(self, username):
+        self.username = username
+        return self
+
+    def setSince(self, since):
+        self.since = since
+        return self
+
+    def setUntil(self, until):
+        self.until = until
+        return self
+
+    def setQuerySearch(self, querySearch):
+        self.querySearch = querySearch
+        return self
+
+    def setMaxTweets(self, maxTweets):
+        self.maxTweets = maxTweets
+        return self
+
+    def setAllTweets(self, allTweets=False):
+        self.allTweets = allTweets

--- a/got/manager/TweetManager.py
+++ b/got/manager/TweetManager.py
@@ -90,6 +90,10 @@ class TweetManager:
 		if hasattr(tweetCriteria, 'querySearch'):
 			urlGetData += ' ' + tweetCriteria.querySearch
 
+		if hasattr(tweetCriteria, 'allTweets'):
+			if tweetCriteria.allTweets:
+				url = "https://twitter.com/i/search/timeline?f=tweets&q=%s&src=typd&max_position=%s"
+
 		url = url % (urllib.quote(urlGetData), refreshCursor)
 
 		headers = [

--- a/got/manager/TweetManager.py
+++ b/got/manager/TweetManager.py
@@ -3,120 +3,116 @@ from .. import models
 from pyquery import PyQuery
 
 class TweetManager:
+	
+	def __init__(self):
+		pass
+		
+	@staticmethod
+	def getTweets(tweetCriteria, receiveBuffer = None, bufferLength = 100):
+		refreshCursor = ''
+	
+		results = []
+		resultsAux = []
+		cookieJar = cookielib.CookieJar()
 
-    def __init__(self):
-        pass
+		active = True
 
-    @staticmethod
-    def getTweets(tweetCriteria, receiveBuffer = None, bufferLength = 100):
-        refreshCursor = ''
+		while active:
+			json = TweetManager.getJsonReponse(tweetCriteria, refreshCursor, cookieJar)
+			if len(json['items_html'].strip()) == 0:
+				break
 
-        results = []
-        resultsAux = []
-        cookieJar = cookielib.CookieJar()
+			refreshCursor = json['min_position']			
+			tweets = PyQuery(json['items_html'])('div.js-stream-tweet')
+			
+			if len(tweets) == 0:
+				break
+			
+			for tweetHTML in tweets:
+				tweetPQ = PyQuery(tweetHTML)
+				tweet = models.Tweet()
+				
+				usernameTweet = tweetPQ("span.username.js-action-profile-name b").text();
+				txt = re.sub(r"\s+", " ", tweetPQ("p.js-tweet-text").text().replace('# ', '#').replace('@ ', '@'));
+				retweets = int(tweetPQ("span.ProfileTweet-action--retweet span.ProfileTweet-actionCount").attr("data-tweet-stat-count").replace(",", ""));
+				favorites = int(tweetPQ("span.ProfileTweet-action--favorite span.ProfileTweet-actionCount").attr("data-tweet-stat-count").replace(",", ""));
+				dateSec = int(tweetPQ("small.time span.js-short-timestamp").attr("data-time"));
+				id = tweetPQ.attr("data-tweet-id");
+				permalink = tweetPQ.attr("data-permalink-path");
+				
+				geo = ''
+				geoSpan = tweetPQ('span.Tweet-geo')
+				if len(geoSpan) > 0:
+					geo = geoSpan.attr('title')
+				
+				tweet.id = id
+				tweet.permalink = 'https://twitter.com' + permalink
+				tweet.username = usernameTweet
+				tweet.text = txt
+				tweet.date = datetime.datetime.fromtimestamp(dateSec)
+				tweet.retweets = retweets
+				tweet.favorites = favorites
+				tweet.mentions = " ".join(re.compile('(@\\w*)').findall(tweet.text))
+				tweet.hashtags = " ".join(re.compile('(#\\w*)').findall(tweet.text))
+				tweet.geo = geo
+				
+				results.append(tweet)
+				resultsAux.append(tweet)
+				
+				if receiveBuffer and len(resultsAux) >= bufferLength:
+					receiveBuffer(resultsAux)
+					resultsAux = []
+				
+				if tweetCriteria.maxTweets > 0 and len(results) >= tweetCriteria.maxTweets:
+					active = False
+					break
+					
+		
+		if receiveBuffer and len(resultsAux) > 0:
+			receiveBuffer(resultsAux)
+		
+		return results
+	
+	@staticmethod
+	def getJsonReponse(tweetCriteria, refreshCursor, cookieJar):
+		url = "https://twitter.com/i/search/timeline?f=realtime&q=%s&src=typd&max_position=%s"
+		
+		urlGetData = ''
+		if hasattr(tweetCriteria, 'username'):
+			urlGetData += ' from:' + tweetCriteria.username
+			
+		if hasattr(tweetCriteria, 'since'):
+			urlGetData += ' since:' + tweetCriteria.since
+			
+		if hasattr(tweetCriteria, 'until'):
+			urlGetData += ' until:' + tweetCriteria.until
+			
+		if hasattr(tweetCriteria, 'querySearch'):
+			urlGetData += ' ' + tweetCriteria.querySearch
 
-        active = True
+		url = url % (urllib.quote(urlGetData), refreshCursor)
 
-        while active:
-            json = TweetManager.getJsonReponse(tweetCriteria, refreshCursor, cookieJar)
-            if len(json['items_html'].strip()) == 0:
-                break
+		headers = [
+			('Host', "twitter.com"),
+			('User-Agent', "Mozilla/5.0 (Windows NT 6.1; Win64; x64)"),
+			('Accept', "application/json, text/javascript, */*; q=0.01"),
+			('Accept-Language', "de,en-US;q=0.7,en;q=0.3"),
+			('X-Requested-With', "XMLHttpRequest"),
+			('Referer', url),
+			('Connection', "keep-alive")
+		]
 
-            refreshCursor = json['min_position']
-            tweets = PyQuery(json['items_html'])('div.js-stream-tweet')
+		opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookieJar))
+		opener.addheaders = headers
 
-            if len(tweets) == 0:
-                break
-
-            for tweetHTML in tweets:
-                tweetPQ = PyQuery(tweetHTML)
-                tweet = models.Tweet()
-
-                usernameTweet = tweetPQ("span.username.js-action-profile-name b").text();
-                txt = re.sub(r"\s+", " ", tweetPQ("p.js-tweet-text").text().replace('# ', '#').replace('@ ', '@'));
-                retweets = int(tweetPQ("span.ProfileTweet-action--retweet span.ProfileTweet-actionCount").attr("data-tweet-stat-count").replace(",", ""));
-                favorites = int(tweetPQ("span.ProfileTweet-action--favorite span.ProfileTweet-actionCount").attr("data-tweet-stat-count").replace(",", ""));
-                dateSec = int(tweetPQ("small.time span.js-short-timestamp").attr("data-time"));
-                id = tweetPQ.attr("data-tweet-id");
-                permalink = tweetPQ.attr("data-permalink-path");
-
-                geo = ''
-                geoSpan = tweetPQ('span.Tweet-geo')
-                if len(geoSpan) > 0:
-                    geo = geoSpan.attr('title')
-
-                tweet.id = id
-                tweet.permalink = 'https://twitter.com' + permalink
-                tweet.username = usernameTweet
-                tweet.text = txt
-                tweet.date = datetime.datetime.fromtimestamp(dateSec)
-                tweet.retweets = retweets
-                tweet.favorites = favorites
-                tweet.mentions = " ".join(re.compile('(@\\w*)').findall(tweet.text))
-                tweet.hashtags = " ".join(re.compile('(#\\w*)').findall(tweet.text))
-                tweet.geo = geo
-
-                results.append(tweet)
-                resultsAux.append(tweet)
-
-                if receiveBuffer and len(resultsAux) >= bufferLength:
-                    receiveBuffer(resultsAux)
-                    resultsAux = []
-
-                if tweetCriteria.maxTweets > 0 and len(results) >= tweetCriteria.maxTweets:
-                    active = False
-                    break
-
-
-        if receiveBuffer and len(resultsAux) > 0:
-            receiveBuffer(resultsAux)
-
-        return results
-
-    @staticmethod
-    def getJsonReponse(tweetCriteria, refreshCursor, cookieJar):
-        url = "https://twitter.com/i/search/timeline?f=realtime&q=%s&src=typd&max_position=%s"
-
-        urlGetData = ''
-        if hasattr(tweetCriteria, 'username'):
-            urlGetData += ' from:' + tweetCriteria.username
-
-        if hasattr(tweetCriteria, 'since'):
-            urlGetData += ' since:' + tweetCriteria.since
-
-        if hasattr(tweetCriteria, 'until'):
-            urlGetData += ' until:' + tweetCriteria.until
-
-        if hasattr(tweetCriteria, 'querySearch'):
-            urlGetData += ' ' + tweetCriteria.querySearch
-
-        if hasattr(tweetCriteria, 'allTweets'):
-            if tweetCriteria.allTweets:
-                url = "https://twitter.com/i/search/timeline?f=tweets&q=%s&src=typd&max_position=%s"
-
-        url = url % (urllib.quote(urlGetData), refreshCursor)
-
-        headers = [
-            ('Host', "twitter.com"),
-            ('User-Agent', "Mozilla/5.0 (Windows NT 6.1; Win64; x64)"),
-            ('Accept', "application/json, text/javascript, */*; q=0.01"),
-            ('Accept-Language', "de,en-US;q=0.7,en;q=0.3"),
-            ('X-Requested-With', "XMLHttpRequest"),
-            ('Referer', url),
-            ('Connection', "keep-alive")
-        ]
-
-        opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookieJar))
-        opener.addheaders = headers
-
-        try:
-            response = opener.open(url)
-            jsonResponse = response.read()
-        except:
-            print "Twitter weird response. Try to see on browser: https://twitter.com/search?q=%s&src=typd" % urllib.quote(urlGetData)
-            sys.exit()
-            return
-
-        dataJson = json.loads(jsonResponse)
-
-        return dataJson
+		try:
+			response = opener.open(url)
+			jsonResponse = response.read()
+		except:
+			print "Twitter weird response. Try to see on browser: https://twitter.com/search?q=%s&src=typd" % urllib.quote(urlGetData)
+			sys.exit()
+			return
+		
+		dataJson = json.loads(jsonResponse)
+		
+		return dataJson		

--- a/got/manager/TweetManager.py
+++ b/got/manager/TweetManager.py
@@ -3,116 +3,120 @@ from .. import models
 from pyquery import PyQuery
 
 class TweetManager:
-	
-	def __init__(self):
-		pass
-		
-	@staticmethod
-	def getTweets(tweetCriteria, receiveBuffer = None, bufferLength = 100):
-		refreshCursor = ''
-	
-		results = []
-		resultsAux = []
-		cookieJar = cookielib.CookieJar()
 
-		active = True
+    def __init__(self):
+        pass
 
-		while active:
-			json = TweetManager.getJsonReponse(tweetCriteria, refreshCursor, cookieJar)
-			if len(json['items_html'].strip()) == 0:
-				break
+    @staticmethod
+    def getTweets(tweetCriteria, receiveBuffer = None, bufferLength = 100):
+        refreshCursor = ''
 
-			refreshCursor = json['min_position']			
-			tweets = PyQuery(json['items_html'])('div.js-stream-tweet')
-			
-			if len(tweets) == 0:
-				break
-			
-			for tweetHTML in tweets:
-				tweetPQ = PyQuery(tweetHTML)
-				tweet = models.Tweet()
-				
-				usernameTweet = tweetPQ("span.username.js-action-profile-name b").text();
-				txt = re.sub(r"\s+", " ", tweetPQ("p.js-tweet-text").text().replace('# ', '#').replace('@ ', '@'));
-				retweets = int(tweetPQ("span.ProfileTweet-action--retweet span.ProfileTweet-actionCount").attr("data-tweet-stat-count").replace(",", ""));
-				favorites = int(tweetPQ("span.ProfileTweet-action--favorite span.ProfileTweet-actionCount").attr("data-tweet-stat-count").replace(",", ""));
-				dateSec = int(tweetPQ("small.time span.js-short-timestamp").attr("data-time"));
-				id = tweetPQ.attr("data-tweet-id");
-				permalink = tweetPQ.attr("data-permalink-path");
-				
-				geo = ''
-				geoSpan = tweetPQ('span.Tweet-geo')
-				if len(geoSpan) > 0:
-					geo = geoSpan.attr('title')
-				
-				tweet.id = id
-				tweet.permalink = 'https://twitter.com' + permalink
-				tweet.username = usernameTweet
-				tweet.text = txt
-				tweet.date = datetime.datetime.fromtimestamp(dateSec)
-				tweet.retweets = retweets
-				tweet.favorites = favorites
-				tweet.mentions = " ".join(re.compile('(@\\w*)').findall(tweet.text))
-				tweet.hashtags = " ".join(re.compile('(#\\w*)').findall(tweet.text))
-				tweet.geo = geo
-				
-				results.append(tweet)
-				resultsAux.append(tweet)
-				
-				if receiveBuffer and len(resultsAux) >= bufferLength:
-					receiveBuffer(resultsAux)
-					resultsAux = []
-				
-				if tweetCriteria.maxTweets > 0 and len(results) >= tweetCriteria.maxTweets:
-					active = False
-					break
-					
-		
-		if receiveBuffer and len(resultsAux) > 0:
-			receiveBuffer(resultsAux)
-		
-		return results
-	
-	@staticmethod
-	def getJsonReponse(tweetCriteria, refreshCursor, cookieJar):
-		url = "https://twitter.com/i/search/timeline?f=realtime&q=%s&src=typd&max_position=%s"
-		
-		urlGetData = ''
-		if hasattr(tweetCriteria, 'username'):
-			urlGetData += ' from:' + tweetCriteria.username
-			
-		if hasattr(tweetCriteria, 'since'):
-			urlGetData += ' since:' + tweetCriteria.since
-			
-		if hasattr(tweetCriteria, 'until'):
-			urlGetData += ' until:' + tweetCriteria.until
-			
-		if hasattr(tweetCriteria, 'querySearch'):
-			urlGetData += ' ' + tweetCriteria.querySearch
+        results = []
+        resultsAux = []
+        cookieJar = cookielib.CookieJar()
 
-		url = url % (urllib.quote(urlGetData), refreshCursor)
+        active = True
 
-		headers = [
-			('Host', "twitter.com"),
-			('User-Agent', "Mozilla/5.0 (Windows NT 6.1; Win64; x64)"),
-			('Accept', "application/json, text/javascript, */*; q=0.01"),
-			('Accept-Language', "de,en-US;q=0.7,en;q=0.3"),
-			('X-Requested-With', "XMLHttpRequest"),
-			('Referer', url),
-			('Connection', "keep-alive")
-		]
+        while active:
+            json = TweetManager.getJsonReponse(tweetCriteria, refreshCursor, cookieJar)
+            if len(json['items_html'].strip()) == 0:
+                break
 
-		opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookieJar))
-		opener.addheaders = headers
+            refreshCursor = json['min_position']
+            tweets = PyQuery(json['items_html'])('div.js-stream-tweet')
 
-		try:
-			response = opener.open(url)
-			jsonResponse = response.read()
-		except:
-			print "Twitter weird response. Try to see on browser: https://twitter.com/search?q=%s&src=typd" % urllib.quote(urlGetData)
-			sys.exit()
-			return
-		
-		dataJson = json.loads(jsonResponse)
-		
-		return dataJson		
+            if len(tweets) == 0:
+                break
+
+            for tweetHTML in tweets:
+                tweetPQ = PyQuery(tweetHTML)
+                tweet = models.Tweet()
+
+                usernameTweet = tweetPQ("span.username.js-action-profile-name b").text();
+                txt = re.sub(r"\s+", " ", tweetPQ("p.js-tweet-text").text().replace('# ', '#').replace('@ ', '@'));
+                retweets = int(tweetPQ("span.ProfileTweet-action--retweet span.ProfileTweet-actionCount").attr("data-tweet-stat-count").replace(",", ""));
+                favorites = int(tweetPQ("span.ProfileTweet-action--favorite span.ProfileTweet-actionCount").attr("data-tweet-stat-count").replace(",", ""));
+                dateSec = int(tweetPQ("small.time span.js-short-timestamp").attr("data-time"));
+                id = tweetPQ.attr("data-tweet-id");
+                permalink = tweetPQ.attr("data-permalink-path");
+
+                geo = ''
+                geoSpan = tweetPQ('span.Tweet-geo')
+                if len(geoSpan) > 0:
+                    geo = geoSpan.attr('title')
+
+                tweet.id = id
+                tweet.permalink = 'https://twitter.com' + permalink
+                tweet.username = usernameTweet
+                tweet.text = txt
+                tweet.date = datetime.datetime.fromtimestamp(dateSec)
+                tweet.retweets = retweets
+                tweet.favorites = favorites
+                tweet.mentions = " ".join(re.compile('(@\\w*)').findall(tweet.text))
+                tweet.hashtags = " ".join(re.compile('(#\\w*)').findall(tweet.text))
+                tweet.geo = geo
+
+                results.append(tweet)
+                resultsAux.append(tweet)
+
+                if receiveBuffer and len(resultsAux) >= bufferLength:
+                    receiveBuffer(resultsAux)
+                    resultsAux = []
+
+                if tweetCriteria.maxTweets > 0 and len(results) >= tweetCriteria.maxTweets:
+                    active = False
+                    break
+
+
+        if receiveBuffer and len(resultsAux) > 0:
+            receiveBuffer(resultsAux)
+
+        return results
+
+    @staticmethod
+    def getJsonReponse(tweetCriteria, refreshCursor, cookieJar):
+        url = "https://twitter.com/i/search/timeline?f=realtime&q=%s&src=typd&max_position=%s"
+
+        urlGetData = ''
+        if hasattr(tweetCriteria, 'username'):
+            urlGetData += ' from:' + tweetCriteria.username
+
+        if hasattr(tweetCriteria, 'since'):
+            urlGetData += ' since:' + tweetCriteria.since
+
+        if hasattr(tweetCriteria, 'until'):
+            urlGetData += ' until:' + tweetCriteria.until
+
+        if hasattr(tweetCriteria, 'querySearch'):
+            urlGetData += ' ' + tweetCriteria.querySearch
+
+        if hasattr(tweetCriteria, 'allTweets'):
+            if tweetCriteria.allTweets:
+                url = "https://twitter.com/i/search/timeline?f=tweets&q=%s&src=typd&max_position=%s"
+
+        url = url % (urllib.quote(urlGetData), refreshCursor)
+
+        headers = [
+            ('Host', "twitter.com"),
+            ('User-Agent', "Mozilla/5.0 (Windows NT 6.1; Win64; x64)"),
+            ('Accept', "application/json, text/javascript, */*; q=0.01"),
+            ('Accept-Language', "de,en-US;q=0.7,en;q=0.3"),
+            ('X-Requested-With', "XMLHttpRequest"),
+            ('Referer', url),
+            ('Connection', "keep-alive")
+        ]
+
+        opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookieJar))
+        opener.addheaders = headers
+
+        try:
+            response = opener.open(url)
+            jsonResponse = response.read()
+        except:
+            print "Twitter weird response. Try to see on browser: https://twitter.com/search?q=%s&src=typd" % urllib.quote(urlGetData)
+            sys.exit()
+            return
+
+        dataJson = json.loads(jsonResponse)
+
+        return dataJson


### PR DESCRIPTION
The twitter web search interface has a "Top" tab, for tweets corresponding to a given search that Twitter believes users have engaged with most, and a "Live" tab, for all tweets that correspond to a given search. GetOldTweets currently returns tweets from the "Top" tab - this pull request adds an attribute called "allTweets" to TweetCriteria that lets the user choose whether they want results from "Top Tweets" or "Live Tweets". Setting allTweets to "True" returns results from "Live" tab, and setting allTweets to "False" (or leaving it unset) returns results from "Top" tab. 