### PR TITLE
added: ability to specify proxy for each query (using urllib2)

### DIFF
--- a/got/manager/TweetManager.py
+++ b/got/manager/TweetManager.py
@@ -8,7 +8,7 @@ class TweetManager:
 		pass
 		
 	@staticmethod
-	def getTweets(tweetCriteria, receiveBuffer = None, bufferLength = 100):
+	def getTweets(tweetCriteria, receiveBuffer=None, bufferLength=100, proxy=None):
 		refreshCursor = ''
 	
 		results = []
@@ -21,7 +21,7 @@ class TweetManager:
 		active = True
 
 		while active:
-			json = TweetManager.getJsonReponse(tweetCriteria, refreshCursor, cookieJar)
+			json = TweetManager.getJsonReponse(tweetCriteria, refreshCursor, cookieJar, proxy)
 			if len(json['items_html'].strip()) == 0:
 				break
 
@@ -77,7 +77,7 @@ class TweetManager:
 		return results
 	
 	@staticmethod
-	def getJsonReponse(tweetCriteria, refreshCursor, cookieJar):
+	def getJsonReponse(tweetCriteria, refreshCursor, cookieJar, proxy):
 		url = "https://twitter.com/i/search/timeline?f=tweets&q=%s&src=typd&max_position=%s"
 		
 		urlGetData = ''
@@ -109,7 +109,10 @@ class TweetManager:
 			('Connection', "keep-alive")
 		]
 
-		opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookieJar))
+		if proxy:
+			opener = urllib2.build_opener(urllib2.ProxyHandler({'http': proxy, 'https': proxy}), urllib2.HTTPCookieProcessor(cookieJar))
+		else:
+			opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookieJar))
 		opener.addheaders = headers
 
 		try:

--- a/got3/manager/TweetManager.py
+++ b/got3/manager/TweetManager.py
@@ -8,7 +8,7 @@ class TweetManager:
 		pass
 		
 	@staticmethod
-	def getTweets(tweetCriteria, receiveBuffer = None, bufferLength = 100):
+	def getTweets(tweetCriteria, receiveBuffer=None, bufferLength=100, proxy=None):
 		refreshCursor = ''
 	
 		results = []
@@ -18,7 +18,7 @@ class TweetManager:
 		active = True
 
 		while active:
-			json = TweetManager.getJsonReponse(tweetCriteria, refreshCursor, cookieJar)
+			json = TweetManager.getJsonReponse(tweetCriteria, refreshCursor, cookieJar, proxy)
 			if len(json['items_html'].strip()) == 0:
 				break
 
@@ -84,7 +84,7 @@ class TweetManager:
 		return results
 	
 	@staticmethod
-	def getJsonReponse(tweetCriteria, refreshCursor, cookieJar):
+	def getJsonReponse(tweetCriteria, refreshCursor, cookieJar, proxy):
 		url = "https://twitter.com/i/search/timeline?f=realtime&q=%s&src=typd&%smax_position=%s"
 		
 		urlGetData = ''
@@ -117,7 +117,10 @@ class TweetManager:
 			('Connection', "keep-alive")
 		]
 
-		opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cookieJar))
+		if proxy:
+			opener = urllib2.build_opener(urllib2.ProxyHandler({'http': proxy, 'https': proxy}), urllib2.HTTPCookieProcessor(cookieJar))
+		else:
+			opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookieJar))
 		opener.addheaders = headers
 
 		try:


### PR DESCRIPTION
This commit simply adds one parameter (proxy) to the getTweets staticmethod. It specifies a string with the proxy and port as follows "proxy:port" example "196.23.34.1:80". This will enable the query to berun over that specified proxy.