### PR TITLE
Improve exception handling for urllib

### DIFF
--- a/got3/manager/TweetManager.py
+++ b/got3/manager/TweetManager.py
@@ -20,14 +20,17 @@ class TweetManager:
 		while active:
 			json = TweetManager.getJsonReponse(tweetCriteria, refreshCursor, cookieJar)
 			if not json:  # An exception in getJsonResponse might raise a TypeError,  where json is NoneType.
+				active = False
 				break
 			if len(json['items_html'].strip()) == 0:
+				active = False
 				break
 
 			refreshCursor = json['min_position']			
 			tweets = PyQuery(json['items_html'])('div.js-stream-tweet')
 			
 			if len(tweets) == 0:
+				active = False
 				break
 			
 			for tweetHTML in tweets:

--- a/got3/manager/TweetManager.py
+++ b/got3/manager/TweetManager.py
@@ -19,6 +19,8 @@ class TweetManager:
 
 		while active:
 			json = TweetManager.getJsonReponse(tweetCriteria, refreshCursor, cookieJar)
+			if not json:  # An exception in getJsonResponse might raise a TypeError,  where json is NoneType.
+				break
 			if len(json['items_html'].strip()) == 0:
 				break
 
@@ -123,12 +125,14 @@ class TweetManager:
 		try:
 			response = opener.open(url)
 			jsonResponse = response.read()
-		except:
+		except urllib.error.HTTPError as e:
 			#print("Twitter weird response. Try to see on browser: ", url)
 			print("Twitter weird response. Try to see on browser: https://twitter.com/search?q=%s&src=typd" % urllib.parse.quote(urlGetData))
-			print("Unexpected error:", sys.exc_info()[0])
-			sys.exit()
-			return
+			print("Unexpected error: {} code: {}", sys.exc_info()[0], e.code)
+
+		except urllib.error.URLError as e:
+			printer("Twitter weird response. Try to see on browser: https://twitter.com/search?q=%s&src=typd" % urllib.parse.quote(urlGetData))
+			print("Unexpected error: {} reason: {}", sys.exc_info()[0], e.reason)
 		
 		dataJson = json.loads(jsonResponse.decode())
 		


### PR DESCRIPTION
I run your code in a for-loop where I send a call to getTweets() with a small time period at a time to not timeout. However, I noticed that the exception handling is causing such a for-loop to freeze.

Here's the solution I used. 

I added [the suggested(https://docs.python.org/3.1/howto/urllib2.html)] exception handling for urllib in the py3 version.

The if-clause might be a crappy way of checking if the variable 'json' is of NoneType, but it seems to work.

Actually, the first commit didn't do it. I now also added 'active = False' to the problem-checks of the response. Might improve things.

Thanks for a very useful library! 🥇 