### PR TITLE
Update f-parameter to 'tweets' in got3 also

### DIFF
--- a/got3/manager/TweetManager.py
+++ b/got3/manager/TweetManager.py
@@ -85,7 +85,7 @@ class TweetManager:
 	
 	@staticmethod
 	def getJsonReponse(tweetCriteria, refreshCursor, cookieJar, proxy):
-		url = "https://twitter.com/i/search/timeline?f=realtime&q=%s&src=typd&%smax_position=%s"
+		url = "https://twitter.com/i/search/timeline?f=tweets&q=%s&src=typd&%smax_position=%s"
 		
 		urlGetData = ''
 		if hasattr(tweetCriteria, 'username'):


### PR DESCRIPTION
I noticed that the f-parameter is changed from 'realtime' to 'tweets', which reflects recent changes to twitter.com source code in got, but not in got3.