### PR TITLE
py35

### DIFF
--- a/Exporter.py
+++ b/Exporter.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 import sys,getopt,datetime,codecs
-if sys.version_info[0] < 3:
-    import got
-else:
-    import got3 as got
+# if sys.version_info[0] < 3:
+#     import got
+# else:
+#     import got3 as got
+import got3 as got
 
 def main(argv):
 
@@ -13,7 +14,7 @@ def main(argv):
 
 	if len(argv) == 1 and argv[0] == '-h':
 		f = open('exporter_help_text.txt', 'r')
-		print f.read()
+		print(f.read())
 		f.close()
 
 		return

--- a/Exporter.py
+++ b/Exporter.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 import sys,getopt,datetime,codecs
-# if sys.version_info[0] < 3:
-#     import got
-# else:
-#     import got3 as got
-import got3 as got
+if sys.version_info[0] < 3:
+    import got
+else:
+    import got3 as got
 
 def main(argv):
 

--- a/got3/manager/TweetManager.py
+++ b/got3/manager/TweetManager.py
@@ -118,9 +118,9 @@ class TweetManager:
 		]
 
 		if proxy:
-			opener = urllib2.build_opener(urllib2.ProxyHandler({'http': proxy, 'https': proxy}), urllib2.HTTPCookieProcessor(cookieJar))
+			opener = urllib.request.build_opener(urllib.ProxyHandler({'http': proxy, 'https': proxy}), urllib.request.HTTPCookieProcessor(cookieJar))
 		else:
-			opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookieJar))
+			opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cookieJar))
 		opener.addheaders = headers
 
 		try:


### PR DESCRIPTION
Fix two issues in move from Python 2.7 to Python 3.5

- call print as function
- use urllib.request instead of urllib2
