### PR TITLE
Fix urllib import error in Py 3.5.2

### DIFF
--- a/got3/manager/TweetManager.py
+++ b/got3/manager/TweetManager.py
@@ -118,9 +118,9 @@ class TweetManager:
 		]
 
 		if proxy:
-			opener = urllib2.build_opener(urllib2.ProxyHandler({'http': proxy, 'https': proxy}), urllib2.HTTPCookieProcessor(cookieJar))
+			opener = urllib.request.build_opener(urllib.ProxyHandler({'http': proxy, 'https': proxy}), urllib.request.HTTPCookieProcessor(cookieJar))
 		else:
-			opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookieJar))
+			opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cookieJar))
 		opener.addheaders = headers
 
 		try:


### PR DESCRIPTION
Error in Python 3.5.2:

    AttributeError: module 'urllib' has no attribute 'build_opener'

This goes for the whole lines replaced.