### PR TITLE
Ignore withheld tweets

### DIFF
--- a/Exporter.py
+++ b/Exporter.py
@@ -64,7 +64,7 @@ def main(argv):
 		def receiveBuffer(tweets):
 			for t in tweets:
 				outputFile.write(('\n%s;%s;%d;%d;"%s";%s;%s;%s;"%s";%s' % (t.username, t.date.strftime("%Y-%m-%d %H:%M"), t.retweets, t.favorites, t.text, t.geo, t.mentions, t.hashtags, t.id, t.permalink)))
-			outputFile.flush();
+			outputFile.flush()
 			print('More %d saved on file...\n' % len(tweets))
 
 		got.manager.TweetManager.getTweets(tweetCriteria, receiveBuffer)

--- a/got/manager/TweetManager.py
+++ b/got/manager/TweetManager.py
@@ -25,8 +25,11 @@ class TweetManager:
 			if len(json['items_html'].strip()) == 0:
 				break
 
-			refreshCursor = json['min_position']			
-			tweets = PyQuery(json['items_html'])('div.js-stream-tweet')
+			refreshCursor = json['min_position']
+			scrapedTweets = PyQuery(json['items_html'])
+			#Remove incomplete tweets withheld by Twitter Guidelines
+			scrapedTweets.remove('div.withheld-tweet')
+			tweets = scrapedTweets('div.js-stream-tweet')
 			
 			if len(tweets) == 0:
 				break

--- a/got/manager/TweetManager.py
+++ b/got/manager/TweetManager.py
@@ -38,13 +38,13 @@ class TweetManager:
 				tweetPQ = PyQuery(tweetHTML)
 				tweet = models.Tweet()
 				
-				usernameTweet = tweetPQ("span:first.username.u-dir b").text();
-				txt = re.sub(r"\s+", " ", tweetPQ("p.js-tweet-text").text().replace('# ', '#').replace('@ ', '@'));
-				retweets = int(tweetPQ("span.ProfileTweet-action--retweet span.ProfileTweet-actionCount").attr("data-tweet-stat-count").replace(",", ""));
-				favorites = int(tweetPQ("span.ProfileTweet-action--favorite span.ProfileTweet-actionCount").attr("data-tweet-stat-count").replace(",", ""));
-				dateSec = int(tweetPQ("small.time span.js-short-timestamp").attr("data-time"));
-				id = tweetPQ.attr("data-tweet-id");
-				permalink = tweetPQ.attr("data-permalink-path");
+				usernameTweet = tweetPQ("span:first.username.u-dir b").text()
+				txt = re.sub(r"\s+", " ", tweetPQ("p.js-tweet-text").text().replace('# ', '#').replace('@ ', '@'))
+				retweets = int(tweetPQ("span.ProfileTweet-action--retweet span.ProfileTweet-actionCount").attr("data-tweet-stat-count").replace(",", ""))
+				favorites = int(tweetPQ("span.ProfileTweet-action--favorite span.ProfileTweet-actionCount").attr("data-tweet-stat-count").replace(",", ""))
+				dateSec = int(tweetPQ("small.time span.js-short-timestamp").attr("data-time"))
+				id = tweetPQ.attr("data-tweet-id")
+				permalink = tweetPQ.attr("data-permalink-path")
 				
 				geo = ''
 				geoSpan = tweetPQ('span.Tweet-geo')

--- a/got3/manager/TweetManager.py
+++ b/got3/manager/TweetManager.py
@@ -22,8 +22,11 @@ class TweetManager:
 			if len(json['items_html'].strip()) == 0:
 				break
 
-			refreshCursor = json['min_position']			
-			tweets = PyQuery(json['items_html'])('div.js-stream-tweet')
+			refreshCursor = json['min_position']
+			scrapedTweets = PyQuery(json['items_html'])
+			#Remove incomplete tweets withheld by Twitter Guidelines
+			scrapedTweets.remove('div.withheld-tweet')
+			tweets = scrapedTweets('div.js-stream-tweet')
 			
 			if len(tweets) == 0:
 				break

--- a/got3/manager/TweetManager.py
+++ b/got3/manager/TweetManager.py
@@ -35,13 +35,13 @@ class TweetManager:
 				tweetPQ = PyQuery(tweetHTML)
 				tweet = models.Tweet()
 				
-				usernameTweet = tweetPQ("span.username.js-action-profile-name b").text();
-				txt = re.sub(r"\s+", " ", tweetPQ("p.js-tweet-text").text().replace('# ', '#').replace('@ ', '@'));
-				retweets = int(tweetPQ("span.ProfileTweet-action--retweet span.ProfileTweet-actionCount").attr("data-tweet-stat-count").replace(",", ""));
-				favorites = int(tweetPQ("span.ProfileTweet-action--favorite span.ProfileTweet-actionCount").attr("data-tweet-stat-count").replace(",", ""));
-				dateSec = int(tweetPQ("small.time span.js-short-timestamp").attr("data-time"));
-				id = tweetPQ.attr("data-tweet-id");
-				permalink = tweetPQ.attr("data-permalink-path");
+				usernameTweet = tweetPQ("span.username.js-action-profile-name b").text()
+				txt = re.sub(r"\s+", " ", tweetPQ("p.js-tweet-text").text().replace('# ', '#').replace('@ ', '@'))
+				retweets = int(tweetPQ("span.ProfileTweet-action--retweet span.ProfileTweet-actionCount").attr("data-tweet-stat-count").replace(",", ""))
+				favorites = int(tweetPQ("span.ProfileTweet-action--favorite span.ProfileTweet-actionCount").attr("data-tweet-stat-count").replace(",", ""))
+				dateSec = int(tweetPQ("small.time span.js-short-timestamp").attr("data-time"))
+				id = tweetPQ.attr("data-tweet-id")
+				permalink = tweetPQ.attr("data-permalink-path")
 				user_id = int(tweetPQ("a.js-user-profile-link").attr("data-user-id"))
 				
 				geo = ''


### PR DESCRIPTION
Currently withheld tweets i.e. tweets from profiles which are temporarily or permenantly banned are shown on the twitter timeline but are "withheld" and as a consequence break this API as a "withheld tweet" has no properties.

Unfortunately their structure is identical to that of normal tweets in that they contain the class js-stream-tweet and the rest of the div classes normal tweets have whilst also containing ".withheld-tweet".

To prevent the breaking from withheld tweets they need to be removed.

**N.B.** the attached changes remove these withheld tweets and handle cosmetic cleanup. I've only recently began to notice that twitter has displayed these withheld tweets so this could be a new addition to the timeline DOM or could just be a minor edge case but nevertheless it will persist as an issue particularly using this API to scrape tweets where banned users are more common.

withheld tweet:
<img width="472" alt="withheld-tweet" src="https://user-images.githubusercontent.com/11997409/34393752-a7d40e2c-eb4c-11e7-8b3c-1bc63a9c962e.png">

twitter scraped link:
https://twitter.com/search?q=%20%23Brexit%20OR%20%23StrongerIn%20OR%20%23VoteLeave%20since%3A2016-06-24%20until%3A2016-12-03&src=typd&max_position=TWEET-804621295866417152-804837526057795584

example exporter parameters:
python2.7 Exporter.py --querysearch "#Brexit OR #StrongerIn OR #VoteLeave" --since 2016-12-01 --until 2016-12-03